### PR TITLE
Direct rendering of class-based views, ex: ViewComponent, Phlex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Added support for Phlex and ViewComponent-type views and layouts. ([@dhnaranjo])
+
 ## 0.1.0 (2023-11-09)
 
 - Initial release. ([@palkan][])

--- a/README.md
+++ b/README.md
@@ -80,6 +80,28 @@ ERB
 visit_template source, layout: "custom"
 ```
 
+View components are supported through the `#render_component` helper:
+
+```ruby
+button = ButtonComponent.new(type: :submit) do
+  "Save me!"
+end
+
+render_component button
+```
+
+View component-based layouts are supported as well:
+
+```ruby
+button = ButtonComponent.new(type: :submit) do
+  "Save me!"
+end
+
+render_component button, layout: PreviewLayout
+# or
+render_component button, layout: -> { PreviewLayout }
+```
+
 ### Configuration
 
 The following configuration parameters are available (the default values are shown):

--- a/app/controllers/rails_intest_views/templates_controller.rb
+++ b/app/controllers/rails_intest_views/templates_controller.rb
@@ -8,11 +8,20 @@ module RailsIntestViews
       return head :not_found unless template_config
 
       params = {
-        inline: template_config[:template],
-        layout: RailsIntestViews.config.default_layout
+        inline: template_config[:template]
       }
 
-      params[:layout] = template_config[:layout] if template_config.key?(:layout)
+      params[:layout] = case template_config
+      in {layout: Class => klass}
+        proc { klass }
+      in {layout: Proc => lambda} if lambda.lambda?
+        contents = lambda.call
+        proc { contents }
+      in {layout: layout}
+        layout
+      else
+        RailsIntestViews.config.default_layout
+      end
 
       render(**params)
     end

--- a/lib/rails-intest-views.rb
+++ b/lib/rails-intest-views.rb
@@ -55,6 +55,11 @@ module RailsIntestViews
     def url_for(id)
       File.join(config.mount_path, id)
     end
+
+    def render_component(component)
+      controller = config.templates_controller.constantize
+      controller.renderer.render_to_string(component)
+    end
   end
 
   autoload :RequestHelpers, "rails-intest-views/request_helpers"

--- a/lib/rails-intest-views/capybara_helpers.rb
+++ b/lib/rails-intest-views/capybara_helpers.rb
@@ -6,5 +6,10 @@ module RailsIntestViews
       id = RailsIntestViews.write(source, **options)
       visit RailsIntestViews.url_for(id)
     end
+
+    def visit_component(component, **options)
+      source = RailsIntestViews.render_component(component)
+      visit_template(source, **options)
+    end
   end
 end

--- a/lib/rails-intest-views/request_helpers.rb
+++ b/lib/rails-intest-views/request_helpers.rb
@@ -6,5 +6,10 @@ module RailsIntestViews
       id = RailsIntestViews.write(source, **options)
       get RailsIntestViews.url_for(id)
     end
+
+    def get_component(component, **options)
+      source = RailsIntestViews.render_component(component)
+      get_template(source, **options)
+    end
   end
 end

--- a/test/render_component_test.rb
+++ b/test/render_component_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RenderComponentTest < ActionDispatch::IntegrationTest
+  include RailsIntestViews::RequestHelpers
+
+  class Clicko
+    def render_in(*)
+      <<~ERB
+        <a href="#">Clicko!</a>
+      ERB
+    end
+
+    def format
+      :html
+    end
+  end
+
+  class CustomLayout
+    class << self
+      def render(*)
+        "<h1>Custom template</h1>" + yield
+      end
+      alias_method :identifier, :to_s
+      alias_method :virtual_path, :to_s
+    end
+  end
+
+  def test_default
+    get_component Clicko.new
+
+    assert_empty css_select("h1")
+    assert_select "a", "Clicko!"
+  end
+
+  def test_with_global_layout
+    Rails.configuration.rails_intest_views.default_layout = "application"
+
+    get_component Clicko.new
+
+    assert_select "h1", "Default template"
+    assert_select "a", "Clicko!"
+  ensure
+    Rails.configuration.rails_intest_views.default_layout = nil
+  end
+
+  def test_with_component_layout
+    get_component Clicko.new, layout: CustomLayout
+
+    assert_select "h1", "Custom template"
+    assert_select "a", "Clicko!"
+  end
+
+  def test_with_lambda_layout
+    get_component Clicko.new, layout: -> { CustomLayout }
+
+    assert_select "h1", "Custom template"
+    assert_select "a", "Clicko!"
+  end
+end


### PR DESCRIPTION
## What is the purpose of this pull request?

Rendering components. Fixes: https://github.com/palkan/rails-intest-views/issues/1

## What changes did you make? (overview)

- New method `render_component` renders to string using configured controller.
- `view_component` helper methods pass the output of this to existing `view_template`
- Controller wraps layout passed as class or lambda in proc, `render`s `layout` param hits a proc with `#call` with two arguments which can be ignored and just fails if you pass a class.

## Is there anything you'd like reviewers to focus on?

## Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation

